### PR TITLE
chore: centralize shared type definitions

### DIFF
--- a/compiler/Parser/AST/ASTNode.ts
+++ b/compiler/Parser/AST/ASTNode.ts
@@ -1,3 +1,9 @@
+import {
+    PropertyVisibility,
+    PropertyKind,
+    LiteralKind,
+} from "../../../types/types";
+
 export interface Program {
     type: "Program";
     body: ASTNode[];
@@ -12,8 +18,9 @@ export interface CallExpression {
 export interface Literal {
     type: "Literal";
     value: string | number | boolean;
-    kind: "string" | "number" | "boolean";
+    kind: LiteralKind;
 }
+
 
 export interface Symbol {
     type: "Symbol";
@@ -22,12 +29,13 @@ export interface Symbol {
 
 export interface ClassMember {
     type: "ClassMember";
-    visibility: "pub" | "priv";
-    kind: "field" | "method" | "constructor";
+    visibility: PropertyVisibility;
+    kind: PropertyKind;
     name: string;
     params: string[];
     body: ASTNode[];
 }
+
 
 export interface ClassDeclaration {
     type: "ClassDeclaration";

--- a/types/types.ts
+++ b/types/types.ts
@@ -1,0 +1,12 @@
+// types/types.ts
+
+// ---- Class Modifiers ----
+export type PropertyVisibility = "pub" | "priv";
+
+export type PropertyKind =
+  | "field"
+  | "method"
+  | "constructor";
+
+// ---- Literals ----
+export type LiteralKind = "string" | "number" | "boolean";


### PR DESCRIPTION
This PR centralizes repeated type definitions into `types/types.ts`.

### Changes
- Added shared AST-related types to `types/types.ts`
- Replaced duplicated inline union types in `ASTNode.ts`
- No runtime or logic changes

Closes #5
